### PR TITLE
Remove abstracted_axes jit arg to match jax

### DIFF
--- a/xtils/jitpp.py
+++ b/xtils/jitpp.py
@@ -124,7 +124,6 @@ class jit(Generic[P, T_co]):
         device: jax.Device | None = None,
         backend: str | None = None,
         inline: bool = False,
-        abstracted_axes: Any | None = None,
         chexify_checks: FrozenSet[checkify.ErrorCategory] | None = None,
     ) -> None:
         """Initialize the jit decorator."""
@@ -158,7 +157,6 @@ class jit(Generic[P, T_co]):
             device=device,
             backend=backend,
             inline=inline,
-            abstracted_axes=abstracted_axes,
             donate_argnames=tuple(donate_argnames),
             static_argnames=tuple(static_argnames),
         )


### PR DESCRIPTION
I don't know at which version that was, but `jax.jit` doesn't have an
'abstracted_axes' anymore. I simply remove it here so that I can keep
using xtils.jitpp with the newer jax versions.

Signed-off-by: Fabrice Normandin <normandf@mila.quebec>